### PR TITLE
Fix unittests; load Test.html deps with require instead of script tags

### DIFF
--- a/Tests/Selenium/Tests.html
+++ b/Tests/Selenium/Tests.html
@@ -8,25 +8,43 @@
     <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-1.23.1.css">
     <script src="http://sinonjs.org/releases/sinon-2.3.8.js"></script>
     <script src="http://cdnjs.cloudflare.com/ajax/libs/require.js/2.2.0/require.js"></script>
-    <script src="../../node_modules/applicationinsights-common/bundle/applicationinsights-common.js"></script>
-    <script src="../../node_modules/applicationinsights-core-js/bundle/applicationinsights-core-js.js"></script>
     <script src="aichannel.tests.js"></script>
 
     <script>
         require.config({
+            baseUrl: '../../',
+            // Convenience paths to test reqs
             paths: {
-                qunit: "../External/qunit-1.23.1",
-                bridge: "../../node_modules/grunt-contrib-qunit/phantomjs/bridge"
+                core: 'node_modules/applicationinsights-core-js/bundle/',
+                common: 'node_modules/applicationinsights-common/bundle/',
+                qunit: "Tests/External/qunit-1.23.1"
             }
         });
 
-        require(
-            ["qunit", "Tests/Selenium/aichannel.tests"],
-            function (QUnit, tests) {
+        // Load core & common before channel tests
+        require([
+            'qunit', // Load qunit here instead of with tests, otherwise will not work
+            'core/applicationinsights-core-js',
+            'common/applicationinsights-common'
+        ], function (QUnit, aicore, aicommon) {
+            // aichannel is expecting to import from i.e 'applicationinsights-core-js', so create a temp module
+            define('applicationinsights-core-js', function () { return aicore; });
+            define('applicationinsights-common', function () { return aicommon; });
+
+            require.config({
+                baseUrl: './'
+            });
+
+            require([
+                "Tests/Selenium/aichannel.tests"
+            ], function (tests) {
                 QUnit.start();
                 tests.runTests();
-            }
-        );
+            }, function (err) {
+                console.log('REQUIRE ERROR:', err.toString());
+            });
+
+        });
     </script>
 </head>
 

--- a/Tests/Selenium/aichannel.tests.d.ts
+++ b/Tests/Selenium/aichannel.tests.d.ts
@@ -1,7 +1,5 @@
 /// <reference path="../External/qunit.d.ts" />
 /// <reference path="../External/sinon.d.ts" />
-/// <reference types="applicationinsights-core-js" />
-/// <reference types="applicationinsights-common" />
 /** Wrapper around QUnit asserts. This class has two purposes:
  * - Make Assertion methods easy to discover.
  * - Make them consistent with XUnit assertions in the order of the actual and expected parameter values.

--- a/Tests/tsconfig.json
+++ b/Tests/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "sourceMap": true,
+    "inlineSources": true,
+    "noImplicitAny": false,
+    "module": "amd",
+    "moduleResolution": "Node",
+    "target": "es5",
+    "alwaysStrict": true,
+    "declaration": true
+  },
+  "files": []
+}

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -19,9 +19,10 @@ module.exports = function (grunt) {
                 ]
             },
             test: {
-                tsconfig: './tsconfig.json',
+                tsconfig: './Tests/tsconfig.json',
                 src: [
-                    './Tests/Selenium/*.ts'
+                    './Tests/Selenium/*.ts',
+                    './Tests/*.ts',
                 ],
                 out: 'Tests/Selenium/aichannel.tests.js'
             }


### PR DESCRIPTION
This PR enables unittests to be run out of the box - see also: https://github.com/Microsoft/applicationinsights-core-js/pull/10

