### PR TITLE
Add nullcheck for tags in EnvelopeCreator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,9 @@
 {
     "name": "@microsoft/applicationinsights-channel-js",
-    "version": "1.0.0-beta",
+    "version": "1.0.0-beta.3",
     "description": "Microsoft Application Insights JavaScript SDK Channel",
-    "main": "dist/applicationinsights-channel-js.min.js",
-    "module": "dist-esm/applicationinsights-channel-js.js",
+    "main": "dist-esm/applicationinsights-channel-js.js",
     "types": "types/applicationinsights-channel-js.d.ts",
-    "browser": "browser/applicationinsights-channel-js.min.js",
     "sideEffects": false,
     "repository": "github:Microsoft/applicationinsights-channel-js",
     "scripts": {
@@ -28,7 +26,7 @@
     },
     "dependencies": {
         "@microsoft/applicationinsights-core-js": "^1.0.0-beta.2",
-        "@microsoft/applicationinsights-common": "^1.0.0-beta.3"
+        "@microsoft/applicationinsights-common": "^1.0.0-beta.4"
     },
     "license": "MIT"
 }

--- a/src/EnvelopeCreator.ts
+++ b/src/EnvelopeCreator.ts
@@ -2,7 +2,7 @@
 import {
     IEnvelope, Data, Envelope,
     RemoteDependencyData, Event, Exception,
-    Metric, PageView, Trace, PageViewPerformance, IDependencyTelemetry
+    Metric, PageView, Trace, PageViewPerformance, IDependencyTelemetry, IEventTelemetry
 } from '@microsoft/applicationinsights-common';
 import { 
     ITelemetryItem, CoreUtils,
@@ -125,6 +125,9 @@ export abstract class EnvelopeCreator {
         }
 
         // loop through the envelope tags (extension of Part A) and pick out the ones that should go in outgoing envelope tags
+        if (!telemetryItem.tags) {
+            telemetryItem.tags = [];
+        }
         telemetryItem.tags.forEach((tag) => {
             for (let key in tag) {
                 if (tag.hasOwnProperty(key)) {


### PR DESCRIPTION
When tags aren't added in basic SKU, track calls fail