### PR TITLE
Fix pageviewperformance env creator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-channel-js",
-    "version": "1.0.0-beta.9",
+    "version": "1.0.0-beta.10",
     "description": "Microsoft Application Insights JavaScript SDK Channel",
     "main": "dist/applicationinsights-channel-js.js",
     "module": "dist-esm/applicationinsights-channel-js.js",
@@ -28,7 +28,7 @@
     },
     "dependencies": {
         "@microsoft/applicationinsights-core-js": "^1.0.0-beta.3",
-        "@microsoft/applicationinsights-common": "^1.0.0-beta.10"
+        "@microsoft/applicationinsights-common": "^1.0.0-beta.12"
     },
     "license": "MIT"
 }


### PR DESCRIPTION
- Fix PageViewPerformance envelope creator looking for `baseData.uri` instead of `baseData.url`
- Also removes dead code (duration field does not exist in `IPageViewPerformanceTelemetry`, and is not used in `PageViewPerformance` constructor)