### PR TITLE
Add instrumentationKey override option to channel

### DIFF
--- a/Tests/Sender.tests.ts
+++ b/Tests/Sender.tests.ts
@@ -9,6 +9,7 @@ export class SenderTests extends TestClass {
 
     public testInitialize() {
         this._sender = new Sender();
+        this._sender.initialize({ instrumentationKey: ''}, new AppInsightsCore(), []);
     }
 
     public testCleanup() {

--- a/Tests/Sender.tests.ts
+++ b/Tests/Sender.tests.ts
@@ -9,7 +9,7 @@ export class SenderTests extends TestClass {
 
     public testInitialize() {
         this._sender = new Sender();
-        this._sender.initialize({ instrumentationKey: ''}, new AppInsightsCore(), []);
+        this._sender.initialize({ instrumentationKey: 'iKey' }, new AppInsightsCore(), []);
     }
 
     public testCleanup() {

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -36,6 +36,11 @@ export interface ISenderConfig {
     isRetryDisabled: () => boolean;
 
     isBeaconApiDisabled: () => boolean;
+
+    /**
+     * (Optional) Override the instrumentation key that this channel instance sends to
+     */
+    instrumentationKey: () => string;
 }
 
 export interface IBackendResponse {

--- a/src/Sender.ts
+++ b/src/Sender.ts
@@ -387,7 +387,7 @@ export class Sender implements IChannelControlsAI {
         if (this._config.instrumentationKey() !== orig.instrumentationKey && !CoreUtils.isNullOrUndefined(this._config.instrumentationKey())) {
             envelope = {
                 instrumentationKey: this._config.instrumentationKey(),
-                ...envelope
+                ...orig
             };
         } else {
             envelope = orig;

--- a/src/Sender.ts
+++ b/src/Sender.ts
@@ -386,8 +386,8 @@ export class Sender implements IChannelControlsAI {
         let envelope: ITelemetryItem;
         if (this._config.instrumentationKey() !== orig.instrumentationKey && !CoreUtils.isNullOrUndefined(this._config.instrumentationKey())) {
             envelope = {
-                instrumentationKey: this._config.instrumentationKey(),
-                ...orig
+                ...orig,
+                instrumentationKey: this._config.instrumentationKey()
             };
         } else {
             envelope = orig;

--- a/src/Sender.ts
+++ b/src/Sender.ts
@@ -384,7 +384,7 @@ export class Sender implements IChannelControlsAI {
 
     public _constructEnvelope(orig: ITelemetryItem): IEnvelope {
         let envelope: ITelemetryItem;
-        if (this._config.instrumentationKey() !== orig.instrumentationKey) {
+        if (this._config.instrumentationKey() !== orig.instrumentationKey && !CoreUtils.isNullOrUndefined(this._config.instrumentationKey())) {
             envelope = {
                 instrumentationKey: this._config.instrumentationKey(),
                 ...envelope


### PR DESCRIPTION
- Add ikey field in SenderConfig
-  Override envelope ikey if differs from config iKey (Will spread operator usage break <IE9?)