### PR TITLE
don't retry if online and status 0, most likely adblock

### DIFF
--- a/src/Sender.ts
+++ b/src/Sender.ts
@@ -252,7 +252,8 @@ export class Sender implements IChannelControlsAI {
                 } else {
                     this._onError(payload, this._formatErrorMessageXhr(xhr));
                 }
-            } else if (xhr.status === 0 || Offline.isOffline()) { // offline
+            } else if (Offline.isOffline()) { // offline 
+                // Note: Don't check for staus == 0, since adblock gives this code
                 if (!this._config.isRetryDisabled()) {
                     const offlineBackOffMultiplier = 10; // arbritrary number
                     this._resendPayload(payload, offlineBackOffMultiplier);


### PR DESCRIPTION
Telemetry would pile up in session storage and eventually degrade browser performance for users with adblock. Offline detection is kept, but Sender response status is 0, the telemetry will now be dropped instead of retried.