### PR TITLE
Adding support for expo based (unejected) react-native apps

### DIFF
--- a/src/Offline.ts
+++ b/src/Offline.ts
@@ -16,22 +16,29 @@ export class OfflineListener {
     }
 
     constructor() {
-        if (typeof window === 'undefined') {
-            this.isListening = false;
-        } else if (window && window.addEventListener) {
-            window.addEventListener('online', this._setOnline.bind(this), false);
-            window.addEventListener('offline', this._setOffline.bind(this), false);
-            this.isListening = true;
-        } else if (document && document.body) {
-            (<any>document.body).ononline = this._setOnline.bind(this);
-            (<any>document.body).onoffline = this._setOffline.bind(this)
-            this.isListening = true;
-        } else if (document){
-            (<any>document).ononline = this._setOnline.bind(this);
-            (<any>document).onoffline = this._setOffline.bind(this)
-            this.isListening = true;
-        } else {
-            // Could not find a place to add event listener
+        try
+        {
+            if (typeof window === 'undefined') {
+                this.isListening = false;
+            } else if (window && window.addEventListener) {
+                window.addEventListener('online', this._setOnline.bind(this), false);
+                window.addEventListener('offline', this._setOffline.bind(this), false);
+                this.isListening = true;
+            } else if (document && document.body) {
+                (<any>document.body).ononline = this._setOnline.bind(this);
+                (<any>document.body).onoffline = this._setOffline.bind(this)
+                this.isListening = true;
+            } else if (document){
+                (<any>document).ononline = this._setOnline.bind(this);
+                (<any>document).onoffline = this._setOffline.bind(this)
+                this.isListening = true;
+            } else {
+                // Could not find a place to add event listener
+                this.isListening = false;
+            }
+        } catch (e) {
+
+            //this makes react-native less angry
             this.isListening = false;
         }
     }

--- a/src/Offline.ts
+++ b/src/Offline.ts
@@ -16,8 +16,7 @@ export class OfflineListener {
     }
 
     constructor() {
-        try
-        {
+        try {
             if (typeof window === 'undefined') {
                 this.isListening = false;
             } else if (window && window.addEventListener) {

--- a/src/Sender.ts
+++ b/src/Sender.ts
@@ -116,7 +116,7 @@ export class Sender implements IChannelControlsAI {
         this.identifier = "AppInsightsChannelPlugin"
     }
 
-    public initialize(config: IConfiguration & IConfig, core: IAppInsightsCore, extensions: IPlugin[], request: XMLHttpRequest) :void {
+    public initialize(config: IConfiguration & IConfig, core: IAppInsightsCore, extensions: IPlugin[]) :void {
         this._logger = core.logger;
         this._serializer = new Serializer(core.logger);
 
@@ -136,7 +136,7 @@ export class Sender implements IChannelControlsAI {
         if (!this._config.isBeaconApiDisabled() && Util.IsBeaconApiSupported()) {
             this._sender = this._beaconSender;
         } else {
-            var testXhr = request || new XMLHttpRequest();
+            var testXhr = new XMLHttpRequest();
             if ("withCredentials" in testXhr) {
                 this._sender = this._xhrSender;
                 this._XMLHttpRequestSupported = true;

--- a/src/Sender.ts
+++ b/src/Sender.ts
@@ -136,12 +136,14 @@ export class Sender implements IChannelControlsAI {
         if (!this._config.isBeaconApiDisabled() && Util.IsBeaconApiSupported()) {
             this._sender = this._beaconSender;
         } else {
-            var testXhr = new XMLHttpRequest();
-            if ("withCredentials" in testXhr) {
-                this._sender = this._xhrSender;
-                this._XMLHttpRequestSupported = true;
-            } else if (typeof XDomainRequest !== "undefined") {
-                this._sender = this._xdrSender; //IE 8 and 9
+            if (typeof XMLHttpRequest != "undefined") {
+                var testXhr = new XMLHttpRequest();
+                if ("withCredentials" in testXhr) {
+                    this._sender = this._xhrSender;
+                    this._XMLHttpRequestSupported = true;
+                } else if (typeof XDomainRequest !== "undefined") {
+                    this._sender = this._xdrSender; //IE 8 and 9
+                }
             }
         }
     }

--- a/src/Sender.ts
+++ b/src/Sender.ts
@@ -252,7 +252,8 @@ export class Sender implements IChannelControlsAI {
                 } else {
                     this._onError(payload, this._formatErrorMessageXhr(xhr));
                 }
-            } else if (xhr.status === 0 || Offline.isOffline()) { // offline
+            } else if (Offline.isOffline()) { // offline 
+                // Note: Don't check for staus == 0, since adblock gives this code
                 if (!this._config.isRetryDisabled()) {
                     const offlineBackOffMultiplier = 10; // arbritrary number
                     this._resendPayload(payload, offlineBackOffMultiplier);

--- a/src/Sender.ts
+++ b/src/Sender.ts
@@ -116,7 +116,7 @@ export class Sender implements IChannelControlsAI {
         this.identifier = "AppInsightsChannelPlugin"
     }
 
-    public initialize(config: IConfiguration & IConfig, core: IAppInsightsCore, extensions: IPlugin[]) :void {
+    public initialize(config: IConfiguration & IConfig, core: IAppInsightsCore, extensions: IPlugin[], request: XMLHttpRequest) :void {
         this._logger = core.logger;
         this._serializer = new Serializer(core.logger);
 
@@ -130,20 +130,18 @@ export class Sender implements IChannelControlsAI {
             this._config[field] = () => ConfigurationManager.getConfig(config, field, this.identifier, defaultConfig[field]());
         }
 
-        this._buffer = (Util.canUseSessionStorage() && this._config.enableSessionStorageBuffer)
+        this._buffer = (this._config.enableSessionStorageBuffer && Util.canUseSessionStorage())
             ? new SessionStorageSendBuffer(this._logger, this._config) : new ArraySendBuffer(this._config);
 
         if (!this._config.isBeaconApiDisabled() && Util.IsBeaconApiSupported()) {
             this._sender = this._beaconSender;
         } else {
-            if (typeof XMLHttpRequest != "undefined") {
-                var testXhr = new XMLHttpRequest();
-                if ("withCredentials" in testXhr) {
-                    this._sender = this._xhrSender;
-                    this._XMLHttpRequestSupported = true;
-                } else if (typeof XDomainRequest !== "undefined") {
-                    this._sender = this._xdrSender; //IE 8 and 9
-                }
+            var testXhr = request || new XMLHttpRequest();
+            if ("withCredentials" in testXhr) {
+                this._sender = this._xhrSender;
+                this._XMLHttpRequestSupported = true;
+            } else if (typeof XDomainRequest !== "undefined") {
+                this._sender = this._xdrSender; //IE 8 and 9
             }
         }
     }


### PR DESCRIPTION
@markwolff - thanks for your help the other day.
This comes out of the questions I was asking you in [https://github.com/Microsoft/applicationinsights-core-js/issues/46](url)

Ended up getting it all "working"...

In my repo I got things built up correctly like this:
```
    import { AppInsightsCore, DiagnosticLogger } from '@microsoft/applicationinsights-core-js'
    import { ApplicationInsights } from '@microsoft/applicationinsights-web';
    import { Sender }  from "@microsoft/applicationinsights-channel-js";

    const aiCore = new AppInsightsCore();
    const logger = new DiagnosticLogger();
    let config = {
      instrumentationKey: "instrumentation key",
      loglevelConsole:2,
      loggingLevelTelemetry:2,
      enableDebugExceptions:false,
      enableSessionStorageBuffer: false,
      logger: logger
    };

    let sender = new Sender(config, aiCore, new XMLHttpRequest());
    sender.initialize(config, aiCore);
    aiCore.initialize(config, [sender]);
    let ai = new ApplicationInsights(config);
    ai.appInsights.initialize(config, aiCore, [sender]);
    ai.loadAppInsights(ai, sender);
    ai.trackPageView({name: "MyPage"})
```

There are a few changes in upstream libraries to make it work as well - mostly minor tweaks to fail differently. But... I wanted to get your opinion on whether or not this is the right direction at all.
If it's not obvious I haven't done much js (and zero typescript stuff) - so I'm super concerned about the fact I changed that interface...

Fwiw, it's fitting nicely in my app - trying to get [https://github.com/Azure/react-appinsights](url) working now