### PR TITLE
remove Exception constructor from ExceptionEnvelopeCreator

### DIFF
--- a/src/EnvelopeCreator.ts
+++ b/src/EnvelopeCreator.ts
@@ -373,11 +373,7 @@ export class ExceptionEnvelopeCreator extends EnvelopeCreator {
                 _InternalMessageId.TelemetryEnvelopeInvalid, "telemetryItem.baseData cannot be null.");
         }
 
-        let properties = telemetryItem.baseData.properties;
-        let measurements = telemetryItem.baseData.measurements;
-        let exception = telemetryItem.baseData.error;
-        let severityLevel = telemetryItem.baseData.severityLevel;
-        let baseData = new Exception(logger, exception, properties, measurements, severityLevel);
+        let baseData = telemetryItem.baseData as Exception;
         let data = new Data<Exception>(Exception.dataType, baseData);
         return EnvelopeCreator.createEnvelope<Exception>(logger, Exception.envelopeType, telemetryItem, data);
     }


### PR DESCRIPTION
Tied to...
- https://github.com/Microsoft/ApplicationInsights-JS/issues/772
- https://github.com/Microsoft/ApplicationInsights-JS/pull/774

Part B is generated by analytics plugin so that other extensions have access to real part B prior to it getting to Channel plugins